### PR TITLE
Some compiler-related workarounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GTLIB    := libgtest.a
 TEST     := arff-test
 
 CPP      := g++
-CPPFLAGS := -O2 -Wall
+CPPFLAGS := -O2 -Wall -Wextra -pedantic
 INCLUDE  := -I$(SRCDIR)
 TEST_INCLUDE := $(INCLUDE) -I$(GTESTDIR)/include -I$(GTESTDIR)
 D       := g++

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,18 @@ OBJFILES := $(patsubst %.cpp,%.o,$(SRCFILES))
 TESTDIR  := tests
 GTESTDIR := $(TESTDIR)/gtest
 TESTSRC  := $(shell find $(TESTDIR) -name "*.cpp")
-GTESTSRC := $(shell find $(TESTDIR) -name "*.cc")
+GTESTSRC := $(TESTDIR)/gtest/src/gtest-all.cc
 TESTOBJS := $(patsubst %.cpp,%.o,$(TESTSRC))
 GTOBJS   := $(patsubst %.cc,%.o,$(GTESTSRC))
 GTLIB    := libgtest.a
 TEST     := arff-test
 
 CPP      := g++
-CPPFLAGS := -g -Wall
-INCLUDE  := -I$(SRCDIR) -I$(GTESTDIR)/include -I$(GTESTDIR)
-LD       := g++
-LDFLAGS  := -g -Wall -shared
+CPPFLAGS := -O2 -Wall
+INCLUDE  := -I$(SRCDIR)
+TEST_INCLUDE := $(INCLUDE) -I$(GTESTDIR)/include -I$(GTESTDIR)
+D       := g++
+LDFLAGS  := -O2 -Wall -shared
 AR       := ar
 ARFLAGS  := rcs
 
@@ -40,10 +41,10 @@ doc:
 
 ### unit testing ###
 test: $(TEST)
-	$(TEST)
+	./$(TEST)
 
 $(TEST): $(TESTOBJS) $(GTLIB) $(STATIC)
-	$(CPP) $(CPPFLAGS) -o $@ $^
+	$(CPP) $(CPPFLAGS) -o $@ $^ -lpthread
 
 $(GTLIB): $(GTOBJS)
 	$(AR) $(ARFLAGS) $@ $^
@@ -70,8 +71,11 @@ $(STATIC): $(OBJFILES)
 %.o: %.cpp
 	$(CPP) $(CPPFLAGS) $(INCLUDE) -c -o $@ $<
 
+tests/%.o: tests/%.cpp
+	$(CPP) $(CPPFLAGS) $(TEST_INCLUDE) -c -o $@ $<
+
 %.o: %.cc
-	$(CPP) $(CPPFLAGS) $(INCLUDE) -c -o $@ $<
+	$(CPP) $(CPPFLAGS) $(TEST_INCLUDE) -c -o $@ $<
 
 clean:
 	rm -f $(STATIC) $(DYNAMIC) $(OBJFILES)

--- a/src/arff_data.cpp
+++ b/src/arff_data.cpp
@@ -97,7 +97,7 @@ std::string ArffData::get_date_format(const std::string& name) {
 
 void ArffData::_cross_check_instance(ArffInstance* inst) {
     if(inst == NULL) {
-        THROW("ArffData: input instance pointer is null!");
+        THROW("ArffData: input instance pointer is null!", 0);
     }
     if(inst->size() != m_num_attrs) {
         THROW("%s: instance size and num-attrs mismatch inst=%d attrs=%d",

--- a/src/arff_token.h
+++ b/src/arff_token.h
@@ -38,7 +38,7 @@ enum ArffTokenEnum {
     /** end of file has been reached */
     END_OF_FILE,
     /** unknown type (usually an error) */
-    UNKNOWN_TOKEN,
+    UNKNOWN_TOKEN
 };
 
 /**

--- a/src/arff_utils.cpp
+++ b/src/arff_utils.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <stdio.h>
 
 #include <arff_utils.h>
 

--- a/src/arff_utils.h
+++ b/src/arff_utils.h
@@ -28,7 +28,7 @@ void throw_ex(const char* file, int64 line, const char* fmt, ...);
 
 /** Handy macro to throw exceptions */
 #define THROW(fmt, ...)                                         \
-    throw_ex(__FILE__, (int64)__LINE__, fmt, ##__VA_ARGS__)
+    throw_ex(__FILE__, (int64)__LINE__, fmt, __VA_ARGS__)
 
 
 /**

--- a/src/arff_value.h
+++ b/src/arff_value.h
@@ -27,7 +27,7 @@ enum ArffValueEnum {
     /** nominal (only used by ArffAttr) */
     NOMINAL,
     /** unknown */
-    UNKNOWN_VAL,
+    UNKNOWN_VAL
 };
 
 /**


### PR DESCRIPTION
First of all, thanks for the nice library for ARFF file I/O!

I wanted to use you library in a machine learning project but at first failed to build everything. On my system, gtest needed `-lpthread` at the end of the linking command line to link successfully, and additionally, it seems `gtest-all.cc` is enough for the gtest static archive (and compiling any other gtest files results in errors because of multiply-defined non inline symbols).

I also did some modifications for make the headers a _bit more_ standards-compilant. The variadic throw macro, I think, cannot be done portably pre-C++11 without some hefty dependencies (e.g. boost::exception). However, `## __VA_ARGS__` is a GNU-extension while `__VA_ARGS__` is standard in C++11 so I removed the `##` bit. Anyways, the code compiles with GNU extensions (as shown by `-pedanctic`) for C++98 or C++03, and without any extensions for C++11 (as shown by, e.g. `-std=c++11 -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic` under clang, although I only did that for the headers. But `-std=c++11 -pedantic` has no warnings in GCC when compiling the static library, either.)

On a slightly unrelated note, I don't think it is too good practice to have a big honkin' macro named `THROW` right in the global scope... What I try to imply that the code is nearly 2 years old, and it might be nice to update it according to "modern" (i.e. C++11) coding style. I understand you probably have no free time available to do that since you have abandoned the project a long time ago. I am hoping to find some time myself to do that (although there is only a very slim chance, unfortunately), maybe with the addition of implementing newer ARFF features like collection-valued attributes... A native library for reading and writing data files used by a popular tool seems like a nice thing to have
